### PR TITLE
feat(pci): allow override of pci ids filepath

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -20,7 +20,7 @@ var db *pciids.DB
 var pciFileEnv = os.Getenv("PCI_IDS_FILE")
 
 func init() {
-	filepath := "/usr/share/misc/pci.ids"
+	filepath := "/usr/share/hwdata/pci.ids"
 	if pciFileEnv != "" {
 		filepath = pciFileEnv
 	}

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -17,8 +17,13 @@ type ProgrammingInterface struct {
 
 var db *pciids.DB
 
+var pciFileEnv = os.Getenv("PCI_IDS_FILE")
+
 func init() {
-	filepath := "/usr/share/hwdata/pci.ids"
+	filepath := "/usr/share/misc/pci.ids"
+	if pciFileEnv != "" {
+		filepath = pciFileEnv
+	}
 	file, _ := os.Open(filepath)
 	scanner := bufio.NewScanner(file)
 	db, _ = pciids.NewDB(scanner)


### PR DESCRIPTION
currently there's no way to override this filepath if your system uses a different location for the pci ids db.